### PR TITLE
Updated supported versions of numpy

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,6 +17,6 @@ The `cesnet-models` package requires Python >=3.10.
 
 | Name         | Version  |
 |--------------|----------|
-| numpy        | <2.0     |
+| numpy        |          |
 | scikit-learn |          |
 | torch        | >=1.10   |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-  "numpy<2.0",
+  "numpy",
   "scikit-learn",
   "torch>=1.10",
 ]


### PR DESCRIPTION
Numpy version no longer needs to be only below version 2 to match numpy version constraints of cesnet-datazoo.